### PR TITLE
Null parameter

### DIFF
--- a/src/main/java/com/github/jonathanhds/sqlbuilder/select/Condition.java
+++ b/src/main/java/com/github/jonathanhds/sqlbuilder/select/Condition.java
@@ -23,12 +23,6 @@ abstract class Condition {
 		}
 	}
 
-	void add(String condition, String parameter) {
-		if (StringUtils.isNotBlank(parameter)) {
-			add(condition, new Object[] { parameter });
-		}
-	}
-
 	void add(Object condition, Object... parameters) {
 		if (ArrayUtils.isNotEmpty(parameters)) {
 			context.addParameters(parameters);

--- a/src/main/java/com/github/jonathanhds/sqlbuilder/select/Condition.java
+++ b/src/main/java/com/github/jonathanhds/sqlbuilder/select/Condition.java
@@ -18,6 +18,8 @@ abstract class Condition {
 	void add(Object condition, Object parameter) {
 		if (parameter != null) {
 			add(condition, new Object[] { parameter });
+		} else {
+			add(extractColumnName(condition.toString()) + " IS NULL");
 		}
 	}
 
@@ -46,6 +48,24 @@ abstract class Condition {
 				add(columnName + " BETWEEN ? AND ?", start, end);
 			}
 		}
+	}
+
+	private String extractColumnName(String condition) {
+		String[] conditions = new String[] {
+			" =",
+			" >",
+			" <",
+			" IN",
+			" IS",
+			" BETWEEN"
+		};
+		String result = condition.toString();
+
+		for (String c : conditions) {
+			result = StringUtils.substringBefore(result, c);
+		}
+
+		return result;
 	}
 
 	protected abstract String getPrefix();

--- a/src/main/java/com/github/jonathanhds/sqlbuilder/select/Condition.java
+++ b/src/main/java/com/github/jonathanhds/sqlbuilder/select/Condition.java
@@ -1,6 +1,7 @@
 package com.github.jonathanhds.sqlbuilder.select;
 
 import com.github.jonathanhds.sqlbuilder.Context;
+import com.github.jonathanhds.sqlbuilder.IllegalQueryException;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -19,7 +20,11 @@ abstract class Condition {
 		if (parameter != null) {
 			add(condition, new Object[] { parameter });
 		} else {
-			add(extractColumnName(condition.toString()) + " IS NULL");
+			if (isEqualCondition(condition.toString())) {
+				add(extractColumnName(condition.toString()) + " IS NULL");
+			} else {
+				throw new IllegalQueryException("Could not solve '" + condition + "' condition with a null parameter");
+			}
 		}
 	}
 
@@ -44,11 +49,18 @@ abstract class Condition {
 		}
 	}
 
+	private Boolean isEqualCondition(String condition) {
+		return StringUtils.contains(condition, " =");
+	}
+
 	private String extractColumnName(String condition) {
 		String[] conditions = new String[] {
 			" =",
 			" >",
+			" >=",
 			" <",
+			" <=",
+			" <>",
 			" IN",
 			" IS",
 			" BETWEEN"

--- a/src/test/java/com/github/jonathanhds/sqlbuilder/select/SelectTest.java
+++ b/src/test/java/com/github/jonathanhds/sqlbuilder/select/SelectTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertThat;
 
 import com.github.jonathanhds.sqlbuilder.builder.QueryBuilderHSQLDB;
 import com.github.jonathanhds.sqlbuilder.builder.QueryBuilderOracle;
+import com.github.jonathanhds.sqlbuilder.IllegalQueryException;
 import com.github.jonathanhds.sqlbuilder.support.*;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -131,22 +132,30 @@ public class SelectTest {
 	}
 
 	@Test
-	public void selectAllFromTableWhereConditionParameterIsNull()
+	public void selectAllFromTableWhereEqualConditionParameterIsNull()
 		throws Exception {
-		List<Person> persons = new QueryBuilderHSQLDB(connection)
+		String sql = new QueryBuilderHSQLDB(connection)
 			.select()
 			.all()
 			.from()
 			.table("PERSON p")
 			.where()
 			.and("p.birthday = ?", getNullValue())
-			.list(new PersonRowMapper());
+			.toString();
 
-		assertThat(persons, hasSize(1));
-		assertThat(
-			persons,
-			containsInAnyOrder(martinLutherKing().setCountry(null))
-		);
+		assertThat(sql, equalTo("SELECT\n*\nFROM\nPERSON p\n\n\nWHERE 1 = 1\nAND p.birthday IS NULL\n"));
+	}
+
+	@Test(expected = IllegalQueryException.class)
+	public void selectAllFromTable_shouldThrowExceptionWhenConditionIsDifferentFromEqualAndParmeterIsNull() {
+		new QueryBuilderHSQLDB(connection)
+			.select()
+			.all()
+			.from()
+			.table("PERSON p")
+			.where()
+			.and("p.birthday >= ?", getNullValue())
+			.toString();
 	}
 
 	@Test

--- a/src/test/java/com/github/jonathanhds/sqlbuilder/select/SelectTest.java
+++ b/src/test/java/com/github/jonathanhds/sqlbuilder/select/SelectTest.java
@@ -46,13 +46,14 @@ public class SelectTest {
 			.table("PERSON p")
 			.list(new PersonRowMapper());
 
-		assertThat(persons, hasSize(3));
+		assertThat(persons, hasSize(4));
 		assertThat(
 			persons,
 			containsInAnyOrder(
 				jonathan().setCountry(null),
 				steveJobs().setCountry(null),
-				domPedro().setCountry(null)
+				domPedro().setCountry(null),
+				martinLutherKing().setCountry(null)
 			)
 		);
 	}
@@ -129,10 +130,15 @@ public class SelectTest {
 			.innerJoin("COUNTRY c ON c.id = p.country_id")
 			.list(new PersonRowMapper());
 
-		assertThat(persons, hasSize(3));
+		assertThat(persons, hasSize(4));
 		assertThat(
 			persons,
-			containsInAnyOrder(jonathan(), steveJobs(), domPedro())
+			containsInAnyOrder(
+				jonathan(),
+				steveJobs(),
+				domPedro(),
+				martinLutherKing()
+			)
 		);
 
 		persons =
@@ -144,10 +150,15 @@ public class SelectTest {
 				.innerJoin("COUNTRY c ON c.id = p.country_id")
 				.list(new PersonRowMapper());
 
-		assertThat(persons, hasSize(3));
+		assertThat(persons, hasSize(4));
 		assertThat(
 			persons,
-			containsInAnyOrder(jonathan(), steveJobs(), domPedro())
+			containsInAnyOrder(
+				jonathan(),
+				steveJobs(),
+				domPedro(),
+				martinLutherKing()
+			)
 		);
 
 		persons =
@@ -160,10 +171,15 @@ public class SelectTest {
 				.where("c.id = p.country_id")
 				.list(new PersonRowMapper());
 
-		assertThat(persons, hasSize(3));
+		assertThat(persons, hasSize(4));
 		assertThat(
 			persons,
-			containsInAnyOrder(jonathan(), steveJobs(), domPedro())
+			containsInAnyOrder(
+				jonathan(),
+				steveJobs(),
+				domPedro(),
+				martinLutherKing()
+			)
 		);
 
 		persons =
@@ -175,10 +191,15 @@ public class SelectTest {
 				.where("c.id = p.country_id")
 				.list(new PersonRowMapper());
 
-		assertThat(persons, hasSize(3));
+		assertThat(persons, hasSize(4));
 		assertThat(
 			persons,
-			containsInAnyOrder(jonathan(), steveJobs(), domPedro())
+			containsInAnyOrder(
+				jonathan(),
+				steveJobs(),
+				domPedro(),
+				martinLutherKing()
+			)
 		);
 
 		persons =
@@ -191,10 +212,15 @@ public class SelectTest {
 				.where("c.id = p.country_id")
 				.list(new PersonRowMapper());
 
-		assertThat(persons, hasSize(3));
+		assertThat(persons, hasSize(4));
 		assertThat(
 			persons,
-			containsInAnyOrder(jonathan(), steveJobs(), domPedro())
+			containsInAnyOrder(
+				jonathan(),
+				steveJobs(),
+				domPedro(),
+				martinLutherKing()
+			)
 		);
 	}
 
@@ -209,11 +235,12 @@ public class SelectTest {
 			.column("p.name", OrderByType.DESC)
 			.list(new PersonRowMapper());
 
-		assertThat(persons, hasSize(3));
+		assertThat(persons, hasSize(4));
 		assertThat(
 			persons,
 			contains(
 				steveJobs().setCountry(null),
+				martinLutherKing().setCountry(null),
 				jonathan().setCountry(null),
 				domPedro().setCountry(null)
 			)
@@ -256,8 +283,8 @@ public class SelectTest {
 			.column("p.birthday")
 			.list(new CountRowMapper());
 
-		assertThat(counts, hasSize(3));
-		assertThat(counts, contains(1, 1, 1));
+		assertThat(counts, hasSize(4));
+		assertThat(counts, contains(1, 1, 1, 1));
 
 		counts =
 			new QueryBuilderHSQLDB(connection)
@@ -268,8 +295,8 @@ public class SelectTest {
 				.groupBy("p.birthday")
 				.list(new CountRowMapper());
 
-		assertThat(counts, hasSize(3));
-		assertThat(counts, contains(1, 1, 1));
+		assertThat(counts, hasSize(4));
+		assertThat(counts, contains(1, 1, 1, 1));
 
 		counts =
 			new QueryBuilderHSQLDB(connection)
@@ -282,7 +309,7 @@ public class SelectTest {
 				.list(new CountRowMapper());
 
 		assertThat(counts, hasSize(2));
-		assertThat(counts, containsInAnyOrder(2, 1));
+		assertThat(counts, containsInAnyOrder(2, 2));
 	}
 
 	@Test
@@ -297,8 +324,8 @@ public class SelectTest {
 			.having("count(c.country_name) > 1")
 			.list(new CountRowMapper());
 
-		assertThat(counts, hasSize(1));
-		assertThat(counts, contains(2));
+		assertThat(counts, hasSize(2));
+		assertThat(counts, contains(2, 2));
 	}
 
 	@Test
@@ -314,8 +341,8 @@ public class SelectTest {
 			.orderBy("c.country_name", DESC)
 			.list(new CountryRowMapper());
 
-		assertThat(countries, hasSize(1));
-		assertThat(countries, contains(brazil()));
+		assertThat(countries, hasSize(2));
+		assertThat(countries, contains(usa(), brazil()));
 
 		countries =
 			new QueryBuilderHSQLDB(connection)
@@ -410,5 +437,9 @@ public class SelectTest {
 
 	private Person jonathan() {
 		return new Person("Jonathan", toDate(1988, 11, 8), brazil());
+	}
+
+	private Person martinLutherKing() {
+		return new Person("Martin Luther King", null, usa());
 	}
 }

--- a/src/test/java/com/github/jonathanhds/sqlbuilder/select/SelectTest.java
+++ b/src/test/java/com/github/jonathanhds/sqlbuilder/select/SelectTest.java
@@ -101,6 +101,36 @@ public class SelectTest {
 	}
 
 	@Test
+	public void selectAllFromTableWhereConditionWithEmptyParameter()
+		throws Exception {
+		List<Person> persons = new QueryBuilderHSQLDB(connection)
+			.select()
+			.all()
+			.from()
+			.table("PERSON p")
+			.where()
+			.and("p.name = ?", "")
+			.list(new PersonRowMapper());
+
+		assertThat(persons, hasSize(0));
+	}
+
+	@Test
+	public void selectAllFromTableWhereConditionWithBlankParameter()
+		throws Exception {
+		List<Person> persons = new QueryBuilderHSQLDB(connection)
+			.select()
+			.all()
+			.from()
+			.table("PERSON p")
+			.where()
+			.and("p.name = ?", " ")
+			.list(new PersonRowMapper());
+
+		assertThat(persons, hasSize(0));
+	}
+
+	@Test
 	public void selectAllFromTableWhereConditionParameterIsNull()
 		throws Exception {
 		List<Person> persons = new QueryBuilderHSQLDB(connection)

--- a/src/test/java/com/github/jonathanhds/sqlbuilder/select/SelectTest.java
+++ b/src/test/java/com/github/jonathanhds/sqlbuilder/select/SelectTest.java
@@ -94,11 +94,29 @@ public class SelectTest {
 			.table("PERSON p")
 			.where()
 			.and("p.name = ?", "Steve Jobs")
-			.and("p.birthday = ?", getNullValue())
 			.list(new PersonRowMapper());
 
 		assertThat(persons, hasSize(1));
 		assertThat(persons, containsInAnyOrder(steveJobs().setCountry(null)));
+	}
+
+	@Test
+	public void selectAllFromTableWhereConditionParameterIsNull()
+		throws Exception {
+		List<Person> persons = new QueryBuilderHSQLDB(connection)
+			.select()
+			.all()
+			.from()
+			.table("PERSON p")
+			.where()
+			.and("p.birthday = ?", getNullValue())
+			.list(new PersonRowMapper());
+
+		assertThat(persons, hasSize(1));
+		assertThat(
+			persons,
+			containsInAnyOrder(martinLutherKing().setCountry(null))
+		);
 	}
 
 	@Test

--- a/src/test/resources/seed.sql
+++ b/src/test/resources/seed.sql
@@ -4,3 +4,4 @@ INSERT INTO country (id, country_name) VALUES (2, 'United States of America');
 INSERT INTO person (id, name, birthday, country_id) VALUES (1, 'Jonathan', DATE'1988-11-08', 1);
 INSERT INTO person (id, name, birthday, country_id) VALUES (2, 'Steve Jobs', DATE'1955-02-24', 2);
 INSERT INTO person (id, name, birthday, country_id) VALUES (3, 'Dom Pedro II', DATE'1825-12-02', 1);
+INSERT INTO person (id, name, birthday, country_id) VALUES (4, 'Martin Luther King', null, 2);


### PR DESCRIPTION
Closes #9 

Changes the `Context` class to handle `null` parameters values.

Code example:
```java
List<Task> tasks = new QueryBuilderHSQLDB(connection)
    .select()
    .all()
    .from("TASKS t")
    .where()
    .and("t.dueDate = ?", null)
    .list(new TaskRowMapper())
```

The output SQL will be:
```sql
SELECT
    *
FROM
    TASKS t
WHERE
    t.dueDate IS NULL
```